### PR TITLE
fix resolveObjectPath to work properly with path parts starting with number

### DIFF
--- a/src/util/resolveObjectPath/index.js
+++ b/src/util/resolveObjectPath/index.js
@@ -13,7 +13,7 @@ export default path => {
     return path.split('.').map(part => {
         const partAsInteger = parseInt(part);
 
-        if (!isNaN(partAsInteger)) {
+        if (!isNaN(partAsInteger) && String(partAsInteger) === part) {
             return partAsInteger;
         }
 

--- a/src/util/resolveObjectPath/index.spec.js
+++ b/src/util/resolveObjectPath/index.spec.js
@@ -8,11 +8,13 @@ describe('Internals: resolveObjectPath', () => {
         expect(resolveObjectPath('a.b.c')).to.deep.equal(['a', 'b', 'c']);
         expect(resolveObjectPath('a.b.c.1')).to.deep.equal(['a', 'b', 'c', 1]);
         expect(resolveObjectPath('a.b.c.1.d.0')).to.deep.equal(['a', 'b', 'c', 1, 'd', 0]);
+        expect(resolveObjectPath('a.1.c1.2d.d.0')).to.deep.equal(['a', 1, 'c1', '2d', 'd', 0]);
     });
 
     it('should leave arrays untouched', () => {
         expect(resolveObjectPath(['a'])).to.deep.equal(['a']);
         expect(resolveObjectPath(['a', 1, 'b'])).to.deep.equal(['a', 1, 'b']);
         expect(resolveObjectPath(['a', '2', 'c'])).to.deep.equal(['a', '2', 'c']);
+        expect(resolveObjectPath(['a', '2', 'c', '3d'])).to.deep.equal(['a', '2', 'c', '3d']);
     });
 });


### PR DESCRIPTION
I got messages `Cannot add an item to a undefined.`, started finding out what's wrong and figured out that resolveObjectPath doesn't work properly with path parts, that start with numbers. So, here's the fix
