### PR TITLE
FEATURE: Export/expose the utils of the package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,3 +32,5 @@ export const $summarize = connections.$summarize;
 export const $traverse = connections.$traverse;
 
 export const $log = effects.$log;
+
+export * from './util/index.js';

--- a/src/util/createPolymorphFunction/index.spec.js
+++ b/src/util/createPolymorphFunction/index.spec.js
@@ -1,0 +1,14 @@
+import {expect} from 'chai';
+import createPolymorphFunction from './index.js';
+
+describe('Internals: createPolymorphFunction', () => {
+    it('should create a polymorph function which can be curried or called with argument lists', () => {
+        const fn = a => b => `foo ${a} ${b}`;
+        const polymorphFn = createPolymorphFunction(fn);
+
+        expect(polymorphFn).to.be.a('function');
+        expect(polymorphFn('bar')).to.be.a('function');
+        expect(polymorphFn('bar')('baz')).to.equal('foo bar baz');
+        expect(polymorphFn('bar', 'baz')).to.equal('foo bar baz');
+    });
+});

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,7 @@
+import createPolymorphFunction from './createPolymorphFunction/index.js';
+import resolveObjectPath from './resolveObjectPath/index.js';
+
+export const utils = {
+	createPolymorphFunction,
+	resolveObjectPath
+};


### PR DESCRIPTION
This commit exports all utils of this package e.g. `import {utils} from 'plow-js'`. Since you may want to create e.g. polymorph functions yourself the utils would be of good use, especially to reduce duplicate code since they are shipped / bundled anyway.

I was not 100% sure if they should be exported with the $ prefix as well but I found an separate utils export to be a bit tidier.

As always, any feedback appreciated :)